### PR TITLE
fix/security-vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -805,10 +805,21 @@
             }
         },
         "eslint-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-            "dev": true
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+                    "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+                    "dev": true
+                }
+            }
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -1040,26 +1051,17 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-            "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+            "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
+                "neo-async": "^2.6.0",
                 "optimist": "^0.6.1",
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.17.11"
-                    }
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1745,9 +1747,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-            "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -1805,9 +1807,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash.get": {
             "version": "4.4.2",
@@ -1912,6 +1914,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
             "dev": true
         },
         "nice-try": {
@@ -2997,20 +3005,20 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-            "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+            "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.17.1",
+                "commander": "~2.20.3",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.17.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
                     "dev": true,
                     "optional": true
                 },


### PR DESCRIPTION
- `run npm audit fix`
- the only fix that couldn't be applied is `subtext`, which has been moved to `@hapi/subtext`. This should be resolved when we eventually get around to updating hapi however